### PR TITLE
fix for attendee modal

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:     Events Tickets Extension: Set default quantity of tickets to 1
  * Description:     An extension that Sets default quantity for tickets
- * Version:         1.1.0
+ * Version:         1.1.1
  * Extension Class: Tribe__Extension__Set__Default__Ticket__QTY
  * Author:          Modern Tribe, Inc.
  * Author URI:      http://m.tri.be/1971

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: events, calendar
 Requires at least: 4.7
 Tested up to: 5.6
 Requires PHP: 5.6
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 License: GPL version 2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -34,6 +34,10 @@ Please visit our [extension library](https://theeventscalendar.com/extensions/) 
 We're always interested in your feedback and our [premium forums](https://theeventscalendar.com/support-forums/) are the best place to flag any issues. Do note, however, that the degree of support we provide for extensions like this one tends to be very limited.
 
 == Changelog ==
+
+= [1.1.1] 2021-11-02 =
+
+* Tweak - Added compatibility for newer Ticket V2 views that have an additional modal with attendee info.
 
 = [1.1.0] 2021-03-04 =
 

--- a/tribe-custom.js
+++ b/tribe-custom.js
@@ -19,7 +19,7 @@
             }
 
             if ( v2Container.length ) {
-                $( '.tribe-tickets__tickets-item-quantity-add' ).trigger( 'click' );
+                $( '.tribe-tickets__tickets-form .tribe-tickets__tickets-item-quantity-add' ).trigger( 'click' );
             }
         },
 

--- a/tribe-custom.js
+++ b/tribe-custom.js
@@ -19,7 +19,7 @@
             }
 
             if ( v2Container.length ) {
-                $( '.tribe-tickets__tickets-form .tribe-tickets__tickets-item-quantity-add' ).trigger( 'click' );
+                $( '.tribe-tickets__tickets-form .tribe-tickets__tickets-item-quantity-add' ).first().trigger( 'click' );
             }
         },
 


### PR DESCRIPTION
When I installed your extension for my client, it worked on the first page load, but because there is a pop up modal that includes a second -/+ input, that modal was broken and did not display attendee information.  This tweak fixes the issue and should work for any V2 form. 

